### PR TITLE
Combine support for MOVAPS and MOVAPD instructions, and also include …

### DIFF
--- a/kordesii/utils/function_tracing/opcodes.py
+++ b/kordesii/utils/function_tracing/opcodes.py
@@ -489,21 +489,16 @@ def INC(cpu_context, ip, mnem, opvalues):
 # TODO: Do we need to handle JUMP instructions for our purpose???
 
 
-@opcode
-def MOVAPD(cpu_context, ip, mnem, opvalues):
-    """ 
-    Move Aligned Packed Double-Precision Floating-Point Values 
-    """
-    opvalues = [opvalue for opvalue in opvalues if opvalue.value is not None]
-    opvalue2 = opvalues[1].value
-    logger.debug("{} 0x{:X} :: Copy {} into {}".format(mnem, ip, opvalue2, idc.print_operand(ip, 0)))
-    set_operand_value(cpu_context, ip, opvalue2, idc.print_operand(ip, 0), idc.get_operand_type(ip, 0), width=opvalues[1].width)
-
-
-@opcode
+@opcode("movapd")
+@opcode("movaps")
+@opcode("movupd")
+@opcode("movups")
 def MOVAPS(cpu_context, ip, mnem, opvalues):
-    """ 
-    Move Aligned Packed Single-Precision Floating-Point Values 
+    """
+    Handle the MOVAPD, MOVAPS, MOVUPD, and MOVUPS instructions in the same manner, a move on a single-precision floating
+    point value
+
+    MOVAPS: Move Aligned Packed Single-Precision Floating-Point Values
     """
     opvalues = [opvalue for opvalue in opvalues if opvalue.value is not None]
     opvalue2 = opvalues[1].value

--- a/kordesii/utils/function_tracing/utils.py
+++ b/kordesii/utils/function_tracing/utils.py
@@ -361,7 +361,7 @@ def get_function_data(offset):
             decompiled.get_func_type(tif)
 
             # Save type for next time.
-            format = decompiled.print_dcl2()
+            format = decompiled.print_dcl()
             # The 2's remove the unknown bytes always found at the start and end.
             idc.SetType(offset, "{};".format(format[2:-2]))
 


### PR DESCRIPTION
…MOVUPS and MOVUPD since all handled the same way. Added fix to utils.py which was using print_dcl2 which was deprecated and is now print_dcl in IDA 7