### PR TITLE
Hooked functions and TypeError fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
+## [Unreleased]
+
+### Changed
+- Alternative IDA installation directory can now be provided with the `IDA_DIR` environment variable.
 
 ## [1.5.0] - 2019-06-20
 ### Added

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ DC3-Kordesii is authored by the Department of Defense Cyber Crime Center (DC3).
 
 ## Dependencies
 DC3-Kordesii requires the following:
-- Windows
 - python 2.7 (32 bit)
 - IDA Pro 7.* (tested with 7.0)
 - *(optional)* Hex Ray's Decompiler for x86/x64 architectures
@@ -48,6 +47,12 @@ For a development mode use the `-e` flag to install in editable mode:
 > git clone https://github.com/Defense-Cyber-Crime-Center/kordesii.git
 > pip install -e ./kordesii
 ```
+
+### Setup IDA location
+
+By default kordesii assumes you are on Windows and have installed IDA under the default location `C:/Program Files/IDA Pro *`.
+If you have installed IDA at a different location or running on another operating system, please set the `IDA_DIR` environment
+to point to where IDA has been installed.
 
 ## Usage
 

--- a/kordesii/core.py
+++ b/kordesii/core.py
@@ -109,14 +109,18 @@ def find_ida(is_64_bit=False):
     Raises:
         IOError: If no installation of IDA could be found.
     """
-    # Find installed IDA paths.
-    ida_dirs = glob.glob(r'C:\Program Files*\IDA *')
+    # Use user defined location if available.
+    if 'IDA_DIR' in os.environ:
+        ida_dirs = [os.environ['IDA_DIR']]
+    else:
+        # Find installed IDA paths.
+        ida_dirs = glob.glob(r'C:\Program Files*\IDA *')
 
-    # Sort by highest version.
-    get_version = lambda path: path.rpartition(' ')[2]
-    ida_dirs.sort(key=get_version, reverse=True)
+        # Sort by highest version.
+        get_version = lambda path: path.rpartition(' ')[2]
+        ida_dirs.sort(key=get_version, reverse=True)
 
-    ida_exe_re = re.compile('idaq?64\.exe' if is_64_bit else 'idaq?\.exe')
+    ida_exe_re = re.compile('idaq?64(\.exe)?$' if is_64_bit else 'idaq?(\.exe)?$')
 
     # Find highest version with a ida.exe or idaq.exe in the directory.
     for ida_dir in ida_dirs:
@@ -268,7 +272,7 @@ def run_ida(reporter,
     command = ' '.join(command)  # Doesn't work unless we convert to string!
 
     logger.debug('Running command: {}'.format(command))
-    process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=sys.platform != 'nt')
 
     atexit.register(process.kill)
 

--- a/kordesii/utils/function_tracing/cpu_context.py
+++ b/kordesii/utils/function_tracing/cpu_context.py
@@ -130,7 +130,10 @@ class Operand(object):
         # If it doesn't, we know that it shouldn't be a function pointer.
         # (plus it saves on time)
         # TODO: Determine if we could have false negatives.
-        if idc.is_loaded(offset) and not idc.guess_type(offset):
+        try:
+            if idc.is_loaded(offset) and not idc.guess_type(offset):
+                return False
+        except TypeError:
             return False
         try:
             utils.get_function_data(offset)

--- a/kordesii/utils/function_tracing/function_tracer.py
+++ b/kordesii/utils/function_tracing/function_tracer.py
@@ -241,6 +241,9 @@ class FunctionTracer(object):
             may return a value to be set to the rax register (or equivalent)
         :return:
         """
+        if isinstance(name_or_start_ea, str):
+            name_or_start_ea = name_or_start_ea.lower()
+
         self._hooks[name_or_start_ea] = func
 
     def clear_hooks(self):
@@ -297,6 +300,9 @@ class TracerCache(object):
             may return a value to be set to the rax register (or equivalent)
         :return:
         """
+        if isinstance(name_or_start_ea, str):
+            name_or_start_ea = name_or_start_ea.lower()
+
         # Hook already created tracers.
         for tracer in self._tracers.values():
             tracer.hook(name_or_start_ea, func)

--- a/kordesii/utils/function_tracing/functions.py
+++ b/kordesii/utils/function_tracing/functions.py
@@ -20,6 +20,10 @@ def get(func_name_or_start_ea):
 
     :return: FunctionTracer object or None
     """
+    # Convert the string to lowercase so it can match the dictionary of built-in functions
+    if isinstance(func_name_or_start_ea, str):
+        func_name_or_start_ea = func_name_or_start_ea.lower()
+
     # First check user defined hooks.
     if USER_DEFINED and func_name_or_start_ea in USER_DEFINED:
         return USER_DEFINED[func_name_or_start_ea]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,7 +80,7 @@ def run_in_ida(request, tmpdir, strings_exe):
     command = ' '.join(command)  # doesn't work unless we convert to a string!
     print('Running IDA with command: {}'.format(command))
 
-    process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=sys.platform != 'nt')
 
     stdout, stderr = process.communicate()
     print(stdout)

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -19,3 +19,41 @@ def test_issue_7():
     wide_string = b'\x00/\x00f\x00a\x00v\x00.\x00i\x00c\x00o'
     context.memory.write(0x123000, wide_string)
     assert context.read_data(0x123000, data_type=function_tracing.WIDE_STRING) == wide_string
+
+
+@pytest.mark.in_ida
+def test_function_case_senstivity():
+    """Tests issue with case sensitivity when hooking functions."""
+    from kordesii.utils import function_tracing
+    from kordesii.utils.function_tracing import functions
+    from kordesii.utils.function_tracing import builtin_funcs
+
+    # Test with known builtin func
+    assert functions.get('lstrcpya') == builtin_funcs.strcpy
+    assert functions.get('lStrcpyA') == builtin_funcs.strcpy
+    assert functions.get('lstrcpyA') == builtin_funcs.strcpy
+
+    def dummy(ctx, func_name, func_args):
+        return
+
+    # Test user defined with global tracer cache
+    function_tracing.hook_tracers('SuperFunc', dummy)
+    tracer = function_tracing.get_tracer(0x00401058)
+    assert functions.get('SuperFunc') is None
+    assert functions.get('SUPERfunc') is None
+    assert functions.get('superfunc') is None
+    with functions.hooks(tracer._hooks):
+        assert functions.get('SuperFunc') == dummy
+        assert functions.get('SUPERfunc') == dummy
+        assert functions.get('superfunc') == dummy
+
+    # Test user defined with local tracer
+    tracer = function_tracing.FunctionTracer(0x00401058)
+    tracer.hook('SuperFunc', dummy)
+    assert functions.get('SuperFunc') is None
+    assert functions.get('SUPERfunc') is None
+    assert functions.get('superfunc') is None
+    with functions.hooks(tracer._hooks):
+        assert functions.get('SuperFunc') == dummy
+        assert functions.get('SUPERfunc') == dummy
+        assert functions.get('superfunc') == dummy


### PR DESCRIPTION
Function names in the built-ins list are all lowercase, but function names used to query the built-in list are not converted to lowercase.

A TypeError is being thrown because idc.is_loaded and idc.guess_type are not being wrapped appropriately when determining if an offset is a function pointer.