### PR TITLE
Bug fix with emulated __alloca_probe

### DIFF
--- a/kordesii/utils/function_tracing/builtin_funcs.py
+++ b/kordesii/utils/function_tracing/builtin_funcs.py
@@ -53,18 +53,6 @@ def _alloca(cpu_context, func_name, func_args):
         return cpu_context.sp - size
 
 
-@builtin_func
-def __alloca_probe(cpu_context, func_name, func_args):
-    """
-    Allocates stack space.
-
-    NOTE: Our memory controller will automatically allocate pages as it writes.
-    Therefore, there is nothing we need to do.
-    """
-    # Return the retn address (which is the ip of the instruction we were called from)
-    return cpu_context.ip
-
-
 @builtin_func('malloc')
 @builtin_func('calloc')
 def malloc(cpu_context, func_name, func_args):


### PR DESCRIPTION
* Remove emulation of built-in function `__alloca_probe, as it is not being handled appropriately.  
* Current implementation returns the current pointer to `eax`, which can cause the stack to be interpreted incorrectly and result in inaccurate functionality.