### PR TITLE
Bugfix with searching memory for single character

### DIFF
--- a/kordesii/utils/function_tracing/memory.py
+++ b/kordesii/utils/function_tracing/memory.py
@@ -269,8 +269,8 @@ class Memory(object):
         _end = self.PAGE_SIZE + len(value) - 1
         if end and end_page_index == page_index + 1:
             _end = min(_end, self.PAGE_SIZE + end_page_offset)
-        if end_page_offset is not None and _end == self.PAGE_SIZE + end_page_offset and _end <= _start:
-            return -1
+            if _end == self.PAGE_SIZE + end_page_offset and _end <= _start:
+                return -1
 
         next_page = self._pages.get(page_index + 1, bytearray(self.PAGE_SIZE))
         offset = (page + next_page).find(value, _start, _end)

--- a/kordesii/utils/function_tracing/memory.py
+++ b/kordesii/utils/function_tracing/memory.py
@@ -269,7 +269,7 @@ class Memory(object):
         _end = self.PAGE_SIZE + len(value) - 1
         if end and end_page_index == page_index + 1:
             _end = min(_end, self.PAGE_SIZE + end_page_offset)
-        if _end == self.PAGE_SIZE + end_page_offset and _end <= _start:
+        if end_page_offset is not None and _end == self.PAGE_SIZE + end_page_offset and _end <= _start:
             return -1
 
         next_page = self._pages.get(page_index + 1, bytearray(self.PAGE_SIZE))

--- a/kordesii/utils/function_tracing/memory.py
+++ b/kordesii/utils/function_tracing/memory.py
@@ -257,7 +257,7 @@ class Memory(object):
         if end and end_page_index == page_index:
             # Since we end in this page, don't attempt to read overlap.
             offset = page.find(value, page_offset, end_page_offset)
-            return offset
+            return page_index << 12 | offset
 
         offset = page.find(value, page_offset)
         if offset != -1:
@@ -269,7 +269,7 @@ class Memory(object):
         _end = self.PAGE_SIZE + len(value) - 1
         if end and end_page_index == page_index + 1:
             _end = min(_end, self.PAGE_SIZE + end_page_offset)
-        if _end <= _start:
+        if _end == self.PAGE_SIZE + end_page_offset and _end <= _start:
             return -1
 
         next_page = self._pages.get(page_index + 1, bytearray(self.PAGE_SIZE))

--- a/tests/test_function_tracing.py
+++ b/tests/test_function_tracing.py
@@ -244,6 +244,12 @@ def test_memory():
     assert m.find_in_segment(b'Idmmn!Vnsme', '.text') == -1
     assert m.find(b'\x5F\x5E\xC3', start=0x004035BD) == 0x004035E0
 
+    # test bugfix when searching single length characters
+    assert m.find(b'h', start=0x0011050) == 0x00121FFB
+    assert m.find(b'h', start=0x0011050, end=0x00121FFB) == -1
+    assert m.find(b'h', start=0x0011050, end=0x00121FFB + 1) == 0x00121FFB
+    assert m.find(b'o', start=0x0011050) == 0x00121FFB + 4
+
     # tests allocations
     first_alloc_ea = m.alloc(10)
     assert first_alloc_ea == m.HEAP_BASE


### PR DESCRIPTION
Fix bug caused by searching context memory for a single character found in the adjacent page