### PR TITLE
fpu_opcodes endswith fix

### DIFF
--- a/kordesii/utils/function_tracing/x86_64/fpu_opcodes.py
+++ b/kordesii/utils/function_tracing/x86_64/fpu_opcodes.py
@@ -92,7 +92,7 @@ def _compute(cpu_context, ip, mnem, operands):
     logger.debug("{} 0x{:X} :: {} {} {} = {}".format(mnem, ip, term1, op_str, term2, result))
 
     # Pop if mnem ends with "p"
-    if mnem.endwith('p'):
+    if mnem.endswith('p'):
         cpu_context.registers.fpu.pop()
 
 


### PR DESCRIPTION
Fix a spelling issue in `_compute` function of `fpu_opcodes` which had `endwith` as opposed to `endswith`, which threw an `AttributeError`