### PR TITLE
Fixes bug where index and base properties of displacement are not signed integers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Added `--force` flag to `Tester` for adding or updating testcases to ignore errors if set. (@ddash-ct)
 
+### Fixed
+- Fixed bug in `function_tracing` displacement operands to interpret `base` and `index` properties as signed integers. (@ddash-ct)
+
 ## [1.6.1] - 2019-09-13
 
 ### Fixed

--- a/kordesii/utils/function_tracing/operands.py
+++ b/kordesii/utils/function_tracing/operands.py
@@ -168,7 +168,8 @@ class Operand(object):
         if not self.has_phrase:
             return None
         base_reg = utils.reg2str(utils.x86_base_reg(self._insn, self._op))
-        return self._cpu_context.registers[base_reg]
+        value = self._cpu_context.registers[base_reg]
+        return utils.signed(value, utils.get_bits())
 
     @property
     def index(self):
@@ -179,7 +180,8 @@ class Operand(object):
         if index_reg == -1:
             return 0
         index_reg = utils.reg2str(index_reg)
-        return self._cpu_context.registers[index_reg]
+        value = self._cpu_context.registers[index_reg]
+        return utils.signed(value, utils.get_bits())
 
     def _calc_displacement(self):
         """


### PR DESCRIPTION
Add interpreting `index` and `base` properties of a displacement as signed integers the same way the `offset` property is, fixes bug which existed as a result of not doing this