### PR TITLE
function-data-fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Changed
+- Allow call operand type to be taken into account when pulling a function signature. This provides better support for dynamically resolved function calls.
+
 ## [2.0.1] - 2020-05-01
 
 ### Changed

--- a/kordesii/utils/function_tracing/cpu_context.py
+++ b/kordesii/utils/function_tracing/cpu_context.py
@@ -507,9 +507,11 @@ class ProcessorContext(object):
             operand = self.operands[0]
             # function pointer can be a memory reference or immediate.
             func_ea = operand.addr or operand.value
+        else:
+            operand = None
 
         try:
-            return FunctionSignature(self, func_ea)
+            return FunctionSignature(self, func_ea, operand=operand)
         except RuntimeError as e:
             # If we fail to get a function signature but force is set, set the type to
             # cdecl with no arguments.

--- a/kordesii/utils/function_tracing/function_tracer.py
+++ b/kordesii/utils/function_tracing/function_tracer.py
@@ -210,8 +210,7 @@ class FunctionTracer(object):
         """
         # Iterate all the paths leading up to ea
         for cpu_context in self.iter_context_at(ea, depth=depth, exhaustive=exhaustive):
-            func_ea = cpu_context.operands[0].value
-            yield cpu_context, cpu_context.get_function_args(func_ea, num_args=num_args)
+            yield cpu_context, cpu_context.get_function_args(num_args=num_args)
 
     def get_function_args(self, ea, depth=0, num_args=None):
         """

--- a/kordesii/utils/function_tracing/functions.py
+++ b/kordesii/utils/function_tracing/functions.py
@@ -11,6 +11,7 @@ import ida_typeinf
 import idc
 
 from . import utils
+from .operands import Operand
 
 logger = logging.getLogger(__name__)
 
@@ -26,19 +27,24 @@ class FunctionSignature(object):
     the apply() function is called.
     """
 
-    def __init__(self, cpu_context, start_ea):
+    def __init__(self, cpu_context, start_ea, operand: Operand = None):
         """
         :param cpu_context: ProcessorContext to use for pulling argument values.
         :param start_ea: Starting address of function to create function signature from.
+        :param operand: Optional Operand object containing the address of the function in it's value.
+            This is used for dynamically resolved functions. (e.g. call eax)
 
         :raises RuntimeError: If a function type could not be created from given ea.
         """
         self._cpu_context = cpu_context
         self.start_ea = start_ea
         # TODO: Possibly move the get_function_data work into this class?
-        self._func_type_data = utils.get_function_data(self.start_ea)
-        tif = ida_typeinf.tinfo_t()
-        ida_nalt.get_tinfo(tif, self.start_ea)
+        self._func_type_data = utils.get_function_data(self.start_ea, operand=operand)
+        if operand:
+            tif = operand._tif
+        else:
+            tif = ida_typeinf.tinfo_t()
+            ida_nalt.get_tinfo(tif, self.start_ea)
         self._tif = tif
 
     def __repr__(self):

--- a/kordesii/utils/function_tracing/operands.py
+++ b/kordesii/utils/function_tracing/operands.py
@@ -7,6 +7,8 @@ import logging
 from copy import deepcopy
 
 import ida_frame
+import ida_nalt
+import ida_typeinf
 import ida_ua
 import idaapi
 import idc
@@ -73,6 +75,12 @@ class Operand(object):
         copy = deepcopy(self, memo)
         self.__deepcopy__ = deepcopy_method
         return copy
+
+    @property
+    def _tif(self):
+        tif = ida_typeinf.tinfo_t()
+        ida_nalt.get_op_tinfo(tif, self.ip, self.idx)
+        return tif
 
     @property
     def _insn(self):


### PR DESCRIPTION
When dynamically resolving APIs, was running into a situation where the resolved API was being stored in a register and the call to the resolved address invoked the register. When attempting to use `function_tracing` on that call address, this resulted in a `RuntimeError` because when the utility attempts to use `FunctionSignature`, it isn't obtaining a `func_type_data_t`, even when the operand type is adjusted to reflect an updated, appropriate type.

Updated the code to allow the call operand type to be taken into account when a function signature is pulled.