### PR TITLE
Opcode typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - Fix to account for getting the correct function data using the operand even if the offset is invalid. This provides better support for dynamically resolved function calls. (@ddash-ct)
-- Fixed typo in `jnp` / `jno` opcodes for `function_tracing`
+- Fixed typo in `jnp` / `jpo` opcodes for `function_tracing`
 
 
 ## [2.1.0] - 2020-06-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - Fix to account for getting the correct function data using the operand even if the offset is invalid. This provides better support for dynamically resolved function calls. (@ddash-ct)
+- Fixed typo in `jnp` / `jno` opcodes for `function_tracing`
 
 
 ## [2.1.0] - 2020-06-05

--- a/kordesii/utils/function_tracing/x86_64/opcodes.py
+++ b/kordesii/utils/function_tracing/x86_64/opcodes.py
@@ -1090,7 +1090,7 @@ def JNO(cpu_context, ip, mnem, operands):
 @opcode("jpo")
 def JNP_JPO(cpu_context, ip, mnem, operands):
     """ Jump Not Parity (PF=0) """
-    if not cpu_context.regiseters.pf:
+    if not cpu_context.registers.pf:
         cpu_context.ip = operands[0].value
 
 


### PR DESCRIPTION
Typo in "registers" for `function_tracing` x86/x64 opcodes `jnp` / `jpo`