### PR TITLE
IDA 7.6 Bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+- In IDA 7.6, imported functions are now function pointers, add checks accordingly
+
 
 ## [2.2.0] - 2020-10-30
 

--- a/kordesii/utils/function_tracing/utils.py
+++ b/kordesii/utils/function_tracing/utils.py
@@ -367,6 +367,12 @@ def get_function_data(offset, operand: Operand = None):
 
     if tif:
         funcdata = ida_typeinf.func_type_data_t()
+
+        # In IDA 7.6, imported functions are now function pointers.
+        # To handle this, check if we need to pull out a pointed object first
+        if tif.is_funcptr():
+            tif = tif.get_pointed_object()
+
         success = tif.get_func_details(funcdata)
         if success:
             # record that we have processed this function before. (and that we can grab it from the offset)

--- a/kordesii/utils/utils.py
+++ b/kordesii/utils/utils.py
@@ -149,6 +149,10 @@ def _is_func_type(ea):
     tif = ida_typeinf.tinfo_t()
     ida_nalt.get_tinfo(tif, ea)
     func_type_data = ida_typeinf.func_type_data_t()
+    # In IDA 7.6, imported functions are now function pointers.
+    # To handle this, check if we need to pull out a pointed object first
+    if tif.is_funcptr():
+        tif = tif.get_pointed_object()
     return bool(tif.get_func_details(func_type_data))
 
 


### PR DESCRIPTION
In IDA 7.6, imported functions are now function pointers