### PR TITLE
Change value of EMPTY for FPU registers to 0.0 instead of None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Changed
+- *function_tracing*
+    - Change value of `EMPTY` for FPU registers to `0.0` instead of `None`
+
+
 ## [2.3.0] - 2021-06-04
 
 ### Added

--- a/kordesii/utils/function_tracing/x86_64/registers.py
+++ b/kordesii/utils/function_tracing/x86_64/registers.py
@@ -114,7 +114,7 @@ class FPURegisters(RegisterMap):
 
     NaN = float("nan")
     INFINITY = float("inf")
-    EMPTY = None
+    EMPTY = 0.0
 
     def __init__(self):
         registers = [


### PR DESCRIPTION
An issue was observed where an `fstp` instruction was being executed as the first FPU opcode in a function, and the `st0` register was initialized to `None`, resulting in a `struct.error` being thrown since the provided value was not type `float`. 